### PR TITLE
add default compass config. allows sprites to work out of the box.

### DIFF
--- a/lib/spar.rb
+++ b/lib/spar.rb
@@ -79,6 +79,9 @@ module Spar
       HamlCoffeeAssets.config.namespace  = "window.HAML"
       HamlCoffeeAssets.config.escapeHtml = false
 
+      Compass.configuration.project_path = "app"
+      Compass.configuration.images_path = "app/images"
+
       if settings['compress']
         env.js_compressor  = Compressor::JS.new
         env.css_compressor = Compressor::CSS.new


### PR DESCRIPTION
Compass' load paths weren't set up, so sprites didn't work out of the box. I've added the bare minimum config here.
