### PR TITLE
ensure compass sprite urls contain the sprockets digest.

### DIFF
--- a/lib/spar.rb
+++ b/lib/spar.rb
@@ -150,3 +150,9 @@ module Sprockets
     include Spar::Helpers
   end
 end
+
+module Sass::Script::Functions
+  def generated_image_url(path, only_path = nil)
+    asset_url(path, Sass::Script::String.new("image"))
+  end
+end


### PR DESCRIPTION
This seems to do the right thing, both with digests enabled and disabled.
