### PR TITLE
only process spar directives within html assets.

### DIFF
--- a/lib/spar/directive_processor.rb
+++ b/lib/spar/directive_processor.rb
@@ -7,7 +7,7 @@ module Spar
     def evaluate(context, locals, &block)
       @result = data
       
-      process_methods
+      process_methods if context.content_type == "text/html"
 
       @result
     end


### PR DESCRIPTION
Heya, ran into some weird problems when trying to include handlebars-1.0.rc.1.js and ember-1.0.0-pre.2.js via sprockets. It turns out that both those javascript files contain several instances of [{ ... }] in the source, and so the spar directive processor is trying to gsub them out and failing. This patch only applies the directive processor if the current asset is an html document. Is this acceptable? Do you think one would ever want to use a spar directive within a non-html file?
