### PR TITLE
Option to change the endpoint of S3 deployments

### DIFF
--- a/lib/spar/deployers/s3_deployer.rb
+++ b/lib/spar/deployers/s3_deployer.rb
@@ -6,6 +6,7 @@ class S3Deployer < Spar::Deployer
     @aws_key       = Spar.settings['aws_key']
     @aws_secret    = Spar.settings['aws_secret']
     @deploy_bucket = Spar.settings['deploy_bucket']
+    @s3_endpoint   = Spar.settings['s3_endpoint'] || AWS.config.s3_endpoint
     unless @aws_key and @aws_secret and @deploy_bucket
       raise "ERROR: You should set :aws_key, :aws_secret, and :deploy_bucket in your config.yml file so you can deploy to S3"
     end
@@ -13,6 +14,7 @@ class S3Deployer < Spar::Deployer
     AWS.config(
       :access_key_id      => @aws_key,
       :secret_access_key  => @aws_secret,
+      :s3_endpoint        => @s3_endpoint
     )
     @s3 = AWS::S3.new
     @bucket  = @s3.buckets[@deploy_bucket]


### PR DESCRIPTION
I've added an option `s3_endpoint` to the S3 deployer to enable deployments to other S3 regions.
An example config to deploy to the Ireland (eu-west) region:

```
production:
  deploy_strategy: s3
  aws_key: "**************"
  aws_secret: "*******************"
  deploy_bucket: "www.example.com"
  s3_endpoint: "s3-eu-west-1.amazonaws.com"
```
