### PR TITLE
Add #partial helper to Spar::Helpers

### DIFF
--- a/lib/spar/helpers.rb
+++ b/lib/spar/helpers.rb
@@ -22,6 +22,16 @@ module Spar
 
     end
 
+    def partial path
+      segments = path.split("/")
+      segments[-1] = "_#{segments[-1]}.html" # assume html content-type and leading underscore
+      segments.unshift(".") # force relative path
+      partial_path = self.resolve(segments.join("/")).to_s # resolve path with sprockets lookup context
+
+      template = Tilt.new(partial_path)
+      template.render
+    end
+
     def path_to(asset_name, options={})
       asset_name = asset_name.logical_path if asset_name.respond_to?(:logical_path)
       path = Helpers.paths.compute_public_path(asset_name, options.merge(:body => true))


### PR DESCRIPTION
Heya, we had a need for a Rails-like render partial helper within spar, so I threw this together. I couldn't get #render working, because there was a naming collision with something in Sprockets, so I named it #partial instead. There might be a better way to do this, and I wanted to gauge your interest in having this feature in Spar at all, so I haven't written tests or documentation for this pull request. Let me know if you're amenable, and I'll go ahead and do that.
