### PR TITLE
load config.rb from project, if it exists.

### DIFF
--- a/lib/spar.rb
+++ b/lib/spar.rb
@@ -112,6 +112,14 @@ module Spar
 
       env
     end
+
+    unless @already_externally_configured
+      @already_externally_configured = true
+      external_config_pathname = Pathname.new(Spar.root).join("config.rb")
+      load external_config_pathname if File.exist?(external_config_pathname)
+    end
+
+    @sprockets
   end
 
   def self.app


### PR DESCRIPTION
Howdy,

I had a need to further configure the sprockets environment, specifically, adding an additional engine:

`Spar.sprockets.register_engine '.emblem', Emblem::Sprockets::Template`

The question is, where to put this? At first, I added it to my config.ru. That worked fine until it was time to deploy, or test with Capybara. After some experimentation, this is the best I could come up with. I'm not super in love with it, but its simple, and it works. What do you think?
